### PR TITLE
Fix bug where an author bio object returned from the API was not handled

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -28,12 +28,12 @@ export default function App() {
 
   return (
     <main>
-      <div class="searchBar">
-        <label style={{marginRight: "6px"}}>
-          Enter Author's Name:
-        </label>
+      <div className="searchBar">
+        <label style={{ marginRight: "6px" }}>Enter Author's Name:</label>
         <input type="text" value={User_Input} onChange={(name) => setName(name.target.value)} />
-        <button style={{marginLeft: "6px"}} onClick={() => Clicked(true)}>Search</button>
+        <button style={{ marginLeft: "6px" }} onClick={() => Clicked(true)}>
+          Search
+        </button>
       </div>
       {Author_Key && (
         <>

--- a/src/AuthorBio.js
+++ b/src/AuthorBio.js
@@ -18,11 +18,11 @@ export default function AuthorBio({ Author_Key, size = "M" }) {
   }, [Author_Key]);
 
   return (
-    <div class="bioSection">
+    <div className="bioSection">
       <div style={{ paddingRight: "20px" }}>
         <img src={`https://covers.openlibrary.org/a/olid/${Author_Key}-${size}.jpg`} />
       </div>
-      {authorBio && <p class="bio">{authorBio}</p>}
+      {authorBio && <p className="bio">{authorBio}</p>}
     </div>
   );
 }

--- a/src/AuthorBio.js
+++ b/src/AuthorBio.js
@@ -10,7 +10,9 @@ export default function AuthorBio({ Author_Key, size = "M" }) {
       fetch(authorUrl, { method: "GET" })
         .then((response) => response.json())
         .then((data) => {
-          setAuthorBio(data.bio || "No biography available.");
+          setAuthorBio(
+            data.bio && data.bio.value ? data.bio.value : data.bio || "No biography available."
+          );
         });
     }
   }, [Author_Key]);

--- a/src/AuthorBooks.js
+++ b/src/AuthorBooks.js
@@ -6,7 +6,7 @@ export default function AuthorBooks({ Author_Key }) {
   const [author, setAuthor] = useState("");
 
   useEffect(() => {
-    const authorWorksUrl = `https://openlibrary.org/authors/${Author_Key}/works.json?limit=15`;
+    const authorWorksUrl = `https://openlibrary.org/authors/${Author_Key}/works.json?limit=10`;
     const authorUrl = `https://openlibrary.org/authors/${Author_Key}.json`;
 
     if (Author_Key) {

--- a/src/AuthorBooks.js
+++ b/src/AuthorBooks.js
@@ -38,10 +38,10 @@ export default function AuthorBooks({ Author_Key }) {
               </thead>
               <tbody>
                 {author_Works.map((work) => (
-                  <tr>
+                  <tr key={work.key}>
                     <td>{work.title}</td>
                     <td>
-                      <BookRating key={`rating${work.key}`} openLibraryKey={work.key} />
+                      <BookRating openLibraryKey={work.key} />
                     </td>
                   </tr>
                 ))}


### PR DESCRIPTION
`data.bio` could be either a string or object. If it is an object, the bio will be located in the `value` property.